### PR TITLE
Automatically clone raft when the raft pinned tag changes (#2087)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,11 +79,6 @@ datasets/*
 ## Doxygen
 cpp/doxygen/html
 
-# Raft symlink
-python/cugraph/cugraph/raft
-python/pylibcugraph/pylibcugraph/raft
-python/_external_repositories/
-
 # created by Dask tests
 python/dask-worker-space
 python/cugraph/dask-worker-space

--- a/SOURCEBUILD.md
+++ b/SOURCEBUILD.md
@@ -75,7 +75,7 @@ conda activate cugraph_dev
 
 
 ### Build and Install Using the `build.sh` Script
-Using the `build.sh` script make compiling and installig cuGraph a breeze.  To build and install, simply do:
+Using the `build.sh` script make compiling and installing cuGraph a breeze.  To build and install, simply do:
 
 ```bash
 $ cd $CUGRAPH_HOME
@@ -144,6 +144,30 @@ This project uses cmake for building the C/C++ library. To configure cmake, run:
   ```
 The default installation locations are `$CMAKE_INSTALL_PREFIX/lib` and `$CMAKE_INSTALL_PREFIX/include/cugraph` respectively.
 
+#### Updating the RAFT branch
+
+`libcugraph` uses the [RAFT](https://github.com/rapidsai/raft) library and there are times when it might be desirable to build against a different RAFT branch, such as when working on new features that might span both RAFT and cuGraph. 
+
+For local development, the `CPM_raft_SOURCE=<path/to/raft/source>` option can be passed to the `cmake` command to enable `libcugraph` to use the local RAFT branch.
+
+To have CI test a `cugraph` pull request against a different RAFT branch, modify the bottom of the `cpp/cmake/thirdparty/get_raft.cmake` file as follows:
+
+```cmake
+# Change pinned tag and fork here to test a commit in CI
+# To use a different RAFT locally, set the CMake variable
+# RPM_raft_SOURCE=/path/to/local/raft
+find_and_configure_raft(VERSION    ${CUGRAPH_MIN_VERSION_raft}
+                        FORK       <your_git_fork>
+                        PINNED_TAG <your_git_branch_or_tag>
+
+                        # When PINNED_TAG above doesn't match cugraph,
+                        # force local raft clone in build directory
+                        # even if it's already installed.
+                        CLONE_ON_PIN     ON
+                        )
+```
+
+When the above change is pushed to a pull request, the continuous integration servers will use the specified RAFT branch to run the cuGraph tests. After the changes in the RAFT branch are merged to the release branch, remember to revert the `get_raft.cmake` file back to the original cuGraph branch.
 
 ### Building and installing the Python package
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -67,6 +67,8 @@ gpuci_mamba_retry install -y \
       "cudf=${MINOR_VERSION}" \
       "librmm=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \
+      "libraft-headers=${MINOR_VERSION}" \
+      "pyraft=${MINOR_VERSION}" \
       "cudatoolkit=$CUDA_REL" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -11,6 +11,8 @@ dependencies:
 - libcudf=22.04.*
 - rmm=22.04.*
 - librmm=22.04.*
+- libraft-headers=22.04.*
+- pyraft=22.04.*
 - cuda-python>=11.5,<12.0
 - dask>=2021.11.1
 - distributed>=2021.11.1

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -11,6 +11,8 @@ dependencies:
 - libcudf=22.04.*
 - rmm=22.04.*
 - librmm=22.04.*
+- libraft-headers=22.04.*
+- pyraft=22.04.*
 - cuda-python>=11.5,<12.0
 - dask>=2021.11.1
 - distributed>=2021.11.1

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -11,6 +11,8 @@ dependencies:
 - libcudf=22.04.*
 - rmm=22.04.*
 - librmm=22.04.*
+- libraft-headers=22.04.*
+- pyraft=22.04.*
 - cuda-python>=11.5,<12.0
 - dask>=2021.11.1
 - distributed>=2021.11.1

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -11,6 +11,8 @@ dependencies:
 - libcudf=22.04.*
 - rmm=22.04.*
 - librmm=22.04.*
+- libraft-headers=22.04.*
+- pyraft=22.04.*
 - cuda-python>=11.5,<12.0
 - dask>=2021.11.1
 - distributed>=2021.11.1

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -29,13 +29,18 @@ requirements:
     - python x.x
     - cython>=0.29,<0.30
     - libcugraph={{ version }}
+    - libraft-headers {{ minor_version }}
+    - pyraft {{ minor_version }}
     - cudf={{ minor_version }}
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
+    - libraft-headers {{ minor_version }}
   run:
     - python x.x
     - libcugraph={{ version }}
+    - libraft-headers {{ minor_version }}
+    - pyraft {{ minor_version }}
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - cmake>=3.20.1
     - doxygen>=1.8.11
     - cudatoolkit {{ cuda_version }}.*
+    - libraft-headers {{ minor_version }}
     - libcugraphops {{ minor_version }}.*
     - librmm {{ minor_version }}.*
     - cudf {{ minor_version }}.*
@@ -47,6 +48,7 @@ requirements:
     - gmock
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    - libraft-headers {{ minor_version }}
     - nccl>=2.9.9
     - ucx-proc=*=gpu
     - libcugraphops {{ minor_version }}.*

--- a/conda/recipes/libcugraph_etl/meta.yaml
+++ b/conda/recipes/libcugraph_etl/meta.yaml
@@ -39,12 +39,12 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
     - libcudf {{ minor_version }}.*
     - libcugraph {{ minor_version }}.*
+    - libraft-headers {{ minor_version }}
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - libcudf {{ minor_version }}.*
     - libcugraph {{ minor_version }}.*
-    - faiss-proc=*=cuda
-    - libfaiss 1.7.0 *_cuda
+    - libraft-headers {{ minor_version }}
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/pylibcugraph/meta.yaml
+++ b/conda/recipes/pylibcugraph/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 
 # Usage:
 #   conda build -c nvidia -c rapidsai -c conda-forge  .
@@ -33,8 +33,10 @@ requirements:
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
     - rmm {{ minor_version }}.*
+    - libraft-headers {{ minor_version }}
   run:
     - python x.x
+    - libraft-headers {{ minor_version }}
     - libcugraph={{ version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
 

--- a/python/cugraph/cugraph/__init__.py
+++ b/python/cugraph/cugraph/__init__.py
@@ -104,7 +104,7 @@ from cugraph.proto.structure import find_bicliques
 
 from cugraph.linear_assignment import hungarian, dense_hungarian
 from cugraph.layout import force_atlas2
-from cugraph.raft import raft_include_test
+from raft import raft_include_test
 from cugraph.comms import comms
 
 from cugraph.sampling import random_walks, rw_path

--- a/python/cugraph/cugraph/comms/comms.pxd
+++ b/python/cugraph/cugraph/comms/comms.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 # cython: embedsignature = True
 # cython: language_level = 3
 
-from cugraph.raft.common.handle cimport *
+from raft.common.handle cimport *
 
 
 cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":

--- a/python/cugraph/cugraph/comms/comms.py
+++ b/python/cugraph/cugraph/comms/comms.py
@@ -11,9 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cugraph.raft.dask.common.comms import Comms as raftComms
-from cugraph.raft.dask.common.comms import get_raft_comm_state
-from cugraph.raft.common.handle import Handle
+from raft.dask.common.comms import Comms as raftComms
+from raft.dask.common.comms import get_raft_comm_state
+from raft.common.handle import Handle
 from cugraph.comms.comms_wrapper import init_subcomms as c_init_subcomms
 from dask.distributed import default_client
 from cugraph.dask.common import read_utils

--- a/python/cugraph/cugraph/comms/comms_wrapper.pyx
+++ b/python/cugraph/cugraph/comms/comms_wrapper.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 # cython: language_level = 3
 
 
-from cugraph.raft.common.handle cimport *
+from raft.common.handle cimport *
 from cugraph.comms.comms cimport init_subcomms as c_init_subcomms
 
 

--- a/python/cugraph/cugraph/community/egonet_wrapper.pyx
+++ b/python/cugraph/cugraph/community/egonet_wrapper.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -25,11 +25,11 @@ from cugraph.structure.graph_utilities cimport (populate_graph_container,
                                                 move as graph_utils_move,
                                                 )
 from cugraph.structure.graph_primtypes cimport move_device_buffer_to_column
-from cugraph.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cugraph.structure import graph_primtypes_wrapper
 from cugraph.community.egonet cimport call_egonet
-from cugraph.raft.common.handle cimport handle_t
-from cugraph.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 
 
 def egonet(input_graph, vertices, radius=1):

--- a/python/cugraph/cugraph/dask/common/input_utils.py
+++ b/python/cugraph/cugraph/dask/common/input_utils.py
@@ -20,7 +20,7 @@ from dask_cudf.core import DataFrame as dcDataFrame
 from dask_cudf.core import Series as daskSeries
 
 import cugraph.comms.comms as Comms
-from cugraph.raft.dask.common.utils import get_client
+from raft.dask.common.utils import get_client
 from cugraph.dask.common.part_utils import _extract_partitions
 from dask.distributed import default_client
 from toolz import first

--- a/python/cugraph/cugraph/dask/common/mg_utils.py
+++ b/python/cugraph/cugraph/dask/common/mg_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -18,7 +18,7 @@ import numba.cuda
 from dask_cuda import LocalCUDACluster
 from dask.distributed import Client
 
-from cugraph.raft.dask.common.utils import default_client
+from raft.dask.common.utils import default_client
 # FIXME: cugraph/__init__.py also imports the comms module, but
 # depending on the import environment, cugraph/comms/__init__.py
 # may be imported instead. The following imports the comms.py

--- a/python/cugraph/cugraph/generators/rmat.pxd
+++ b/python/cugraph/cugraph/generators/rmat.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -18,7 +18,7 @@ from libcpp.utility cimport pair
 
 from rmm._lib.device_buffer cimport device_buffer
 
-from cugraph.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cugraph.structure.graph_utilities cimport graph_generator_t
 
 

--- a/python/cugraph/cugraph/generators/rmat_wrapper.pyx
+++ b/python/cugraph/cugraph/generators/rmat_wrapper.pyx
@@ -22,7 +22,7 @@ import numpy as np
 from rmm._lib.device_buffer cimport device_buffer
 import cudf
 
-from cugraph.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cugraph.structure.graph_utilities cimport graph_generator_t
 from cugraph.generators.rmat cimport (call_generate_rmat_edgelist,
                                       call_generate_rmat_edgelists,

--- a/python/cugraph/cugraph/link_analysis/hits.pxd
+++ b/python/cugraph/cugraph/link_analysis/hits.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 from libcpp cimport bool
 
 from cugraph.structure.graph_utilities cimport graph_container_t
-from cugraph.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 
 
 cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":

--- a/python/cugraph/cugraph/link_analysis/hits_wrapper.pyx
+++ b/python/cugraph/cugraph/link_analysis/hits_wrapper.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -27,7 +27,7 @@ from cugraph.structure.graph_utilities cimport (graph_container_t,
                                                 numberTypeEnum,
                                                 populate_graph_container,
                                                )
-from cugraph.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cugraph.link_analysis cimport hits as c_hits
 
 

--- a/python/cugraph/cugraph/sampling/random_walks_wrapper.pyx
+++ b/python/cugraph/cugraph/sampling/random_walks_wrapper.pyx
@@ -24,7 +24,7 @@ from cugraph.structure.graph_utilities cimport (populate_graph_container,
                                                 graph_container_t,
                                                 numberTypeEnum,
                                                 )
-from cugraph.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cugraph.structure import graph_primtypes_wrapper
 from cugraph.sampling.random_walks cimport (call_random_walks,
                                             call_rw_paths,

--- a/python/cugraph/cugraph/structure/graph_primtypes.pxd
+++ b/python/cugraph/cugraph/structure/graph_primtypes.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,7 +20,7 @@ from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport pair
 from libcpp.vector cimport vector
-from cugraph.raft.common.handle cimport *
+from raft.common.handle cimport *
 from rmm._lib.device_buffer cimport device_buffer
 
 cdef extern from "cugraph/legacy/graph.hpp" namespace "cugraph::legacy":

--- a/python/cugraph/cugraph/structure/graph_utilities.pxd
+++ b/python/cugraph/cugraph/structure/graph_utilities.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -23,7 +23,7 @@ from libcpp.vector cimport vector
 
 from rmm._lib.device_buffer cimport device_buffer
 
-from cugraph.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 
 
 # C++ graph utilities

--- a/python/cugraph/cugraph/structure/renumber_wrapper.pyx
+++ b/python/cugraph/cugraph/structure/renumber_wrapper.pyx
@@ -25,7 +25,7 @@ from libcpp.vector cimport vector
 import cudf
 from rmm._lib.device_buffer cimport device_buffer
 
-from cugraph.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cugraph.structure.graph_utilities cimport (shuffled_vertices_t,
                                                 major_minor_weights_t,
                                                 renum_tuple_t,

--- a/python/cugraph/setup.py
+++ b/python/cugraph/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -33,7 +33,7 @@ import setuptools.command.build_ext
 from setuptools import find_packages, setup, Command
 from setuptools.extension import Extension
 
-from setuputils import use_raft_package, get_environment_option
+from setuputils import get_environment_option
 
 import versioneer
 
@@ -79,13 +79,6 @@ cuda_lib_dir = os.path.join(CUDA_HOME, "lib64")
 
 # Optional location of C++ build folder that can be configured by the user
 libcugraph_path = get_environment_option('CUGRAPH_BUILD_PATH')
-# Optional location of RAFT that can be confugred by the user
-raft_path = get_environment_option('RAFT_PATH')
-
-# FIXME: This could clone RAFT, even if it's not needed (eg. running --clean).
-# deprecated: This functionality will go away after
-# https://github.com/rapidsai/raft/issues/83
-raft_include_dir = use_raft_package(raft_path, libcugraph_path)
 
 if not libcugraph_path:
     libcugraph_path = conda_lib_dir
@@ -98,7 +91,6 @@ extensions = [
                   ucx_include_dir,
                   '../cpp/include',
                   "../thirdparty/cub",
-                  raft_include_dir,
                   os.path.join(conda_include_dir, "libcudacxx"),
                   cuda_include_dir,
                   os.path.dirname(sysconfig.get_path("include"))
@@ -133,7 +125,6 @@ class CleanCommand(Command):
         os.system('rm -rf build')
         os.system('rm -rf dist')
         os.system('rm -rf dask-worker-space')
-        os.system('rm -f cugraph/raft')
         os.system('find . -name "__pycache__" -type d -exec rm -rf {} +')
         os.system('rm -rf *.egg-info')
         os.system('find . -name "*.cpp" -type f -delete')

--- a/python/cugraph/setuputils.py
+++ b/python/cugraph/setuputils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,72 +67,6 @@ def clean_folder(path):
         cython_exts.extend(glob.glob(folder + '/*.cpython*'))
         for file in cython_exts:
             os.remove(file)
-
-
-def use_raft_package(raft_path, cpp_build_path,
-                     git_info_file=None):
-    """
-    Function to use the python code in RAFT in package.raft
-
-    - If RAFT symlink already exists, don't change anything. Use setup.py clean
-        if you want to change RAFT location.
-    - Uses RAFT located in $RAFT_PATH if $RAFT_PATH exists.
-    - Otherwise it will look for RAFT in the libcugraph build folder,
-        located either in the default locations ../cpp/build/raft,
-        ../cpp/build/_deps/raft-src, or in $CUGRAPH_BUILD_PATH.
-    -Otherwise it will clone RAFT into _external_repositories.
-        - Branch/git tag cloned is located in git_info_file in this case.
-
-    Returns
-     -------
-     raft_include_path: Str
-         Path to the C++ include folder of RAFT
-
-    """
-    if os.path.isdir('cugraph/raft'):
-        raft_path = os.path.realpath('cugraph/raft')
-        # walk up two dirs from `python/raft`
-        raft_path = os.path.join(raft_path, '..', '..')
-        print("-- Using existing RAFT folder")
-    elif cpp_build_path and os.path.isdir(os.path.join(cpp_build_path,
-                                                       '_deps/raft-src')):
-        raft_path = os.path.join(cpp_build_path, '_deps/raft-src')
-        raft_path = os.path.realpath(raft_path)
-        print("-- Using existing RAFT folder in CPP build dir from cmake "
-              "FetchContent")
-    elif cpp_build_path and os.path.isdir(os.path.join(cpp_build_path,
-                                                       'raft/src/raft')):
-        raft_path = os.path.join(cpp_build_path, 'raft/src/raft')
-        raft_path = os.path.realpath(raft_path)
-        print("-- Using existing RAFT folder in CPP build dir from cmake "
-              "ExternalProject")
-    elif isinstance(raft_path, (str, os.PathLike)):
-        print('-- Using RAFT_PATH argument')
-    elif os.environ.get('RAFT_PATH', False) is not False:
-        raft_path = str(os.environ['RAFT_PATH'])
-        print('-- Using RAFT_PATH environment variable')
-    else:
-        raft_path, raft_cloned = \
-            clone_repo_if_needed('raft', cpp_build_path,
-                                 git_info_file=git_info_file)
-        raft_path = os.path.join('../../', raft_path)
-
-    raft_path = os.path.realpath(raft_path)
-    print('-- RAFT found at: ' + str(raft_path))
-
-    try:
-        os.symlink(
-            os.path.join(raft_path, 'python/raft'),
-            os.path.join('cugraph/raft')
-        )
-    except FileExistsError:
-        os.remove(os.path.join('cugraph/raft'))
-        os.symlink(
-            os.path.join(raft_path, 'python/raft'),
-            os.path.join('cugraph/raft')
-        )
-
-    return os.path.join(raft_path, 'cpp/include')
 
 
 def clone_repo_if_needed(name, cpp_build_path=None,

--- a/python/pylibcugraph/pylibcugraph/raft/common/TODO
+++ b/python/pylibcugraph/pylibcugraph/raft/common/TODO
@@ -1,0 +1,6 @@
+FIXME: The contents of this directory should be used from RAFT directly, rather than
+being duplicated here.
+
+pylibcugraph should be able to remove the copy of raft code added here once the connected components
+API is updated to use the new cugraph C API. The only reason RAFT is being pulled in is because the
+legacy connected components in pylibcugraph is using it.

--- a/python/pylibcugraph/pylibcugraph/raft/common/cuda.pxd
+++ b/python/pylibcugraph/pylibcugraph/raft/common/cuda.pxd
@@ -1,4 +1,5 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +14,9 @@
 # limitations under the License.
 #
 
-import cugraph.raft
+from cuda.ccudart cimport cudaStream_t
 
+cdef class Stream:
+    cdef cudaStream_t s
 
-def test_raft():
-    assert cugraph.raft.raft_include_test()
+    cdef cudaStream_t getStream(self)

--- a/python/pylibcugraph/pylibcugraph/raft/common/cuda.pyx
+++ b/python/pylibcugraph/pylibcugraph/raft/common/cuda.pyx
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+from cuda.ccudart cimport(
+    cudaStream_t,
+    cudaError_t,
+    cudaSuccess,
+    cudaStreamCreate,
+    cudaStreamDestroy,
+    cudaStreamSynchronize,
+    cudaGetLastError,
+    cudaGetErrorString,
+    cudaGetErrorName
+)
+
+
+class CudaRuntimeError(RuntimeError):
+    def __init__(self, extraMsg=None):
+        cdef cudaError_t e = cudaGetLastError()
+        cdef bytes errMsg = cudaGetErrorString(e)
+        cdef bytes errName = cudaGetErrorName(e)
+        msg = "Error! %s reason='%s'" % (errName.decode(), errMsg.decode())
+        if extraMsg is not None:
+            msg += " extraMsg='%s'" % extraMsg
+        super(CudaRuntimeError, self).__init__(msg)
+
+
+cdef class Stream:
+    """
+    Stream represents a thin-wrapper around cudaStream_t and its operations.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        from raft.common.cuda import Stream
+        stream = Stream()
+        stream.sync()
+        del stream  # optional!
+    """
+    def __cinit__(self):
+        cdef cudaStream_t stream
+        cdef cudaError_t e = cudaStreamCreate(&stream)
+        if e != cudaSuccess:
+            raise CudaRuntimeError("Stream create")
+        self.s = stream
+
+    def __dealloc__(self):
+        self.sync()
+        cdef cudaError_t e = cudaStreamDestroy(self.s)
+        if e != cudaSuccess:
+            raise CudaRuntimeError("Stream destroy")
+
+    def sync(self):
+        """
+        Synchronize on the cudastream owned by this object. Note that this
+        could raise exception due to issues with previous asynchronous
+        launches
+        """
+        cdef cudaError_t e = cudaStreamSynchronize(self.s)
+        if e != cudaSuccess:
+            raise CudaRuntimeError("Stream sync")
+
+    cdef cudaStream_t getStream(self):
+        return self.s

--- a/python/pylibcugraph/pylibcugraph/raft/common/handle.pxd
+++ b/python/pylibcugraph/pylibcugraph/raft/common/handle.pxd
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+
+from libcpp.memory cimport shared_ptr
+from rmm._lib.cuda_stream_view cimport cuda_stream_view
+from rmm._lib.cuda_stream_pool cimport cuda_stream_pool
+from libcpp.memory cimport shared_ptr
+from libcpp.memory cimport unique_ptr
+
+cdef extern from "raft/mr/device/allocator.hpp" \
+        namespace "raft::mr::device" nogil:
+    cdef cppclass allocator:
+        pass
+
+cdef extern from "raft/handle.hpp" namespace "raft" nogil:
+    cdef cppclass handle_t:
+        handle_t() except +
+        handle_t(cuda_stream_view stream_view) except +
+        handle_t(cuda_stream_view stream_view,
+                 shared_ptr[cuda_stream_pool] stream_pool) except +
+        void set_device_allocator(shared_ptr[allocator] a) except +
+        shared_ptr[allocator] get_device_allocator() except +
+        cuda_stream_view get_stream() except +
+        void sync_stream() except +
+
+cdef class Handle:
+    cdef unique_ptr[handle_t] c_obj
+    cdef shared_ptr[cuda_stream_pool] stream_pool
+    cdef int n_streams

--- a/python/pylibcugraph/pylibcugraph/raft/common/handle.pyx
+++ b/python/pylibcugraph/pylibcugraph/raft/common/handle.pyx
@@ -1,0 +1,90 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+# import raft
+from libcpp.memory cimport shared_ptr
+from rmm._lib.cuda_stream_view cimport cuda_stream_per_thread
+from rmm._lib.cuda_stream_view cimport cuda_stream_view
+
+from .cuda cimport Stream
+from .cuda import CudaRuntimeError
+
+
+cdef class Handle:
+    """
+    Handle is a lightweight python wrapper around the corresponding C++ class
+    of handle_t exposed by RAFT's C++ interface. Refer to the header file
+    raft/handle.hpp for interface level details of this struct
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        from raft.common import Stream, Handle
+        stream = Stream()
+        handle = Handle(stream)
+
+        # call algos here
+
+        # final sync of all work launched in the stream of this handle
+        # this is same as `raft.cuda.Stream.sync()` call, but safer in case
+        # the default stream inside the `handle_t` is being used
+        handle.sync()
+        del handle  # optional!
+    """
+
+    def __cinit__(self, stream: Stream = None, n_streams=0):
+        self.n_streams = n_streams
+        if n_streams > 0:
+            self.stream_pool.reset(new cuda_stream_pool(n_streams))
+
+        cdef cuda_stream_view c_stream
+        if stream is None:
+            # this constructor will construct a "main" handle on
+            # per-thread default stream, which is non-blocking
+            self.c_obj.reset(new handle_t(cuda_stream_per_thread,
+                                          self.stream_pool))
+        else:
+            # this constructor constructs a handle on user stream
+            c_stream = cuda_stream_view(stream.getStream())
+            self.c_obj.reset(new handle_t(c_stream,
+                                          self.stream_pool))
+
+    def sync(self):
+        """
+        Issues a sync on the stream set for this handle.
+        """
+        self.c_obj.get()[0].sync_stream()
+
+    def getHandle(self):
+        return <size_t> self.c_obj.get()
+
+    def __getstate__(self):
+        return self.n_streams
+
+    def __setstate__(self, state):
+        self.n_streams = state
+        if self.n_streams > 0:
+            self.stream_pool.reset(new cuda_stream_pool(self.n_streams))
+
+        self.c_obj.reset(new handle_t(cuda_stream_per_thread,
+                                      self.stream_pool))

--- a/python/pylibcugraph/setup.py
+++ b/python/pylibcugraph/setup.py
@@ -18,7 +18,7 @@ import shutil
 
 from setuptools import setup, find_packages, Command
 from setuptools.extension import Extension
-from setuputils import use_raft_package, get_environment_option
+from setuputils import get_environment_option
 
 try:
     from Cython.Distutils.build_ext import new_build_ext as build_ext
@@ -69,13 +69,6 @@ cuda_lib_dir = os.path.join(CUDA_HOME, "lib64")
 
 # Optional location of C++ build folder that can be configured by the user
 libcugraph_path = get_environment_option('CUGRAPH_BUILD_PATH')
-# Optional location of RAFT that can be confugred by the user
-raft_path = get_environment_option('RAFT_PATH')
-
-# FIXME: This could clone RAFT, even if it's not needed (eg. running --clean).
-# deprecated: This functionality will go away after
-# https://github.com/rapidsai/raft/issues/83
-raft_include_dir = use_raft_package(raft_path, libcugraph_path)
 
 if not libcugraph_path:
     libcugraph_path = conda_lib_dir
@@ -97,7 +90,6 @@ class CleanCommand(Command):
         os.system('rm -rf build')
         os.system('rm -rf dist')
         os.system('rm -rf dask-worker-space')
-        os.system('rm -f pylibcugraph/raft')
         os.system('find . -name "__pycache__" -type d -exec rm -rf {} +')
         os.system('rm -rf *.egg-info')
         os.system('find . -name "*.cpp" -type f -delete')
@@ -117,7 +109,6 @@ EXTENSIONS = [
                   ucx_include_dir,
                   "../../cpp/include",
                   "../../thirdparty/cub",
-                  raft_include_dir,
                   os.path.join(conda_include_dir, "libcudacxx"),
                   cuda_include_dir,
                   os.path.dirname(sysconfig.get_path("include"))

--- a/python/pylibcugraph/setuputils.py
+++ b/python/pylibcugraph/setuputils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,72 +67,6 @@ def clean_folder(path):
         cython_exts.extend(glob.glob(folder + '/*.cpython*'))
         for file in cython_exts:
             os.remove(file)
-
-
-def use_raft_package(raft_path, cpp_build_path,
-                     git_info_file=None):
-    """
-    Function to use the python code in RAFT in package.raft
-
-    - If RAFT symlink already exists, don't change anything. Use setup.py clean
-        if you want to change RAFT location.
-    - Uses RAFT located in $RAFT_PATH if $RAFT_PATH exists.
-    - Otherwise it will look for RAFT in the libcugraph build folder,
-        located either in the default locations ../cpp/build/raft,
-        ../cpp/build/_deps/raft-src, or in $CUGRAPH_BUILD_PATH.
-    -Otherwise it will clone RAFT into _external_repositories.
-        - Branch/git tag cloned is located in git_info_file in this case.
-
-    Returns
-     -------
-     raft_include_path: Str
-         Path to the C++ include folder of RAFT
-
-    """
-    if os.path.isdir('pylibcugraph/raft'):
-        raft_path = os.path.realpath('pylibcugraph/raft')
-        # walk up two dirs from `python/raft`
-        raft_path = os.path.join(raft_path, '..', '..')
-        print("-- Using existing RAFT folder")
-    elif cpp_build_path and os.path.isdir(os.path.join(cpp_build_path,
-                                                       '_deps/raft-src')):
-        raft_path = os.path.join(cpp_build_path, '_deps/raft-src')
-        raft_path = os.path.realpath(raft_path)
-        print("-- Using existing RAFT folder in CPP build dir from cmake "
-              "FetchContent")
-    elif cpp_build_path and os.path.isdir(os.path.join(cpp_build_path,
-                                                       'raft/src/raft')):
-        raft_path = os.path.join(cpp_build_path, 'raft/src/raft')
-        raft_path = os.path.realpath(raft_path)
-        print("-- Using existing RAFT folder in CPP build dir from cmake "
-              "ExternalProject")
-    elif isinstance(raft_path, (str, os.PathLike)):
-        print('-- Using RAFT_PATH argument')
-    elif os.environ.get('RAFT_PATH', False) is not False:
-        raft_path = str(os.environ['RAFT_PATH'])
-        print('-- Using RAFT_PATH environment variable')
-    else:
-        raft_path, raft_cloned = \
-            clone_repo_if_needed('raft', cpp_build_path,
-                                 git_info_file=git_info_file)
-        raft_path = os.path.join('../../', raft_path)
-
-    raft_path = os.path.realpath(raft_path)
-    print('-- RAFT found at: ' + str(raft_path))
-
-    try:
-        os.symlink(
-            os.path.join(raft_path, 'python/raft'),
-            os.path.join('pylibcugraph/raft')
-        )
-    except FileExistsError:
-        os.remove(os.path.join('pylibcugraph/raft'))
-        os.symlink(
-            os.path.join(raft_path, 'python/raft'),
-            os.path.join('pylibcugraph/raft')
-        )
-
-    return os.path.join(raft_path, 'cpp/include')
 
 
 def clone_repo_if_needed(name, cpp_build_path=None,


### PR DESCRIPTION
Now that RAFT has official conda packages, it'll be much easier to work locally on cugraph features that rely on the RAFT nightly. 

Working on features that span raft and cugraph should be fairly straightforward to do locally as well, because CPM provides the `CPM_raft_SOURCE` variable that can passed into the `cmake` call to tell the build to use a local working copy of RAFT.

The raft conda packages are now ready to add to the CI conda dependencies and once added, the updating the raft pinned tag in `get_raft.cmake` will no longer work. The option added in this PR will force clone a local version of the pinned tag (both locally in CI) and set the `CPM_raft_SOURCE` to that path.

Authors:
  - Corey J. Nolet (https://github.com/cjnolet)

Approvers:
  - AJ Schmidt (https://github.com/ajschmidt8)
  - Chuck Hastings (https://github.com/ChuckHastings)
  - Rick Ratzel (https://github.com/rlratzel)

URL: https://github.com/rapidsai/cugraph/pull/2087