### PR TITLE
Python code cleanup across docs, wrappers, testing (#2194)

### DIFF
--- a/docs/cugraph/source/api_docs/centrality.rst
+++ b/docs/cugraph/source/api_docs/centrality.rst
@@ -26,4 +26,3 @@ Katz Centrality (MG)
    :toctree: api/
 
    cugraph.dask.centrality.katz_centrality.katz_centrality
-   cugraph.dask.centrality.katz_centrality.call_katz_centrality

--- a/docs/cugraph/source/api_docs/community.rst
+++ b/docs/cugraph/source/api_docs/community.rst
@@ -50,7 +50,6 @@ Louvain (MG)
 .. autosummary::
    :toctree: api/
 
-   cugraph.dask.community.louvain.call_louvain
    cugraph.dask.community.louvain.louvain
 
 Spectral Clustering

--- a/docs/cugraph/source/api_docs/components.rst
+++ b/docs/cugraph/source/api_docs/components.rst
@@ -20,6 +20,5 @@ Connected Components (MG)
 .. autosummary::
    :toctree: api/
 
-   cugraph.dask.components.connectivity.call_wcc
    cugraph.dask.components.connectivity.weakly_connected_components
 

--- a/docs/cugraph/source/api_docs/helper_functions.rst
+++ b/docs/cugraph/source/api_docs/helper_functions.rst
@@ -12,5 +12,13 @@ Methods
 
    cugraph.comms.comms.initialize
    cugraph.comms.comms.destroy
+   cugraph.comms.comms.is_initialized
+   cugraph.comms.comms.get_comms
+   cugraph.comms.comms.get_workers
+   cugraph.comms.comms.get_session_id
+   cugraph.comms.comms.get_2D_partition
+   cugraph.comms.comms.get_default_handle
+   cugraph.comms.comms.get_handle
+   cugraph.comms.comms.get_worker_id
    cugraph.dask.common.read_utils.get_chunksize
 

--- a/docs/cugraph/source/api_docs/link_analysis.rst
+++ b/docs/cugraph/source/api_docs/link_analysis.rst
@@ -12,6 +12,13 @@ HITS
 
    cugraph.hits
 
+HITS (MG)
+---------
+.. autosummary::
+   :toctree: api/
+
+   cugraph.dask.link_analysis.hits.hits
+
 
 Pagerank
 --------

--- a/docs/cugraph/source/api_docs/sampling.rst
+++ b/docs/cugraph/source/api_docs/sampling.rst
@@ -13,3 +13,10 @@ Random Walks
    cugraph.random_walks
    cugraph.ego_graph
    cugraph.experimental.dask.uniform_neighborhood_sampling
+
+Node2Vec
+---------
+.. autosummary::
+   :toctree: api/
+
+   cugraph.node2vec

--- a/docs/cugraph/source/api_docs/structure.rst
+++ b/docs/cugraph/source/api_docs/structure.rst
@@ -75,6 +75,26 @@ Conversion from Other Formats
    cugraph.to_pandas_adjacency
    cugraph.to_pandas_edgelist
 
+NumberMap
+-----------------------------
+.. autosummary::
+   :toctree: api/
+
+   cugraph.structure.NumberMap
+   cugraph.structure.NumberMap.MultiGPU
+   cugraph.structure.NumberMap.SingleGPU
+   cugraph.structure.NumberMap.from_internal_vertex_id
+   cugraph.structure.NumberMap.to_internal_vertex_id
+   cugraph.structure.NumberMap.add_internal_vertex_id
+   cugraph.structure.NumberMap.compute_vals
+   cugraph.structure.NumberMap.compute_vals_types
+   cugraph.structure.NumberMap.generate_unused_column_name
+   cugraph.structure.NumberMap.renumber
+   cugraph.structure.NumberMap.renumber_and_segment
+   cugraph.structure.NumberMap.set_renumbered_col_names
+   cugraph.structure.NumberMap.unrenumber
+   cugraph.structure.NumberMap.vertex_column_size
+
 Other
 -----------------------------
 .. autosummary::
@@ -82,4 +102,3 @@ Other
 
    cugraph.hypergraph
    cugraph.structure.shuffle
-   cugraph.structure.NumberMap

--- a/docs/cugraph/source/api_docs/traversal.rst
+++ b/docs/cugraph/source/api_docs/traversal.rst
@@ -19,7 +19,6 @@ Breadth-first-search (MG)
    :toctree: api/
 
    cugraph.dask.traversal.bfs.bfs
-   cugraph.dask.traversal.bfs.call_bfs
 
 Single-source-shortest-path
 ---------------------------
@@ -36,5 +35,4 @@ Single-source-shortest-path (MG)
 .. autosummary::
    :toctree: api/
 
-   cugraph.dask.traversal.sssp.call_sssp
    cugraph.dask.traversal.sssp.sssp

--- a/python/cugraph/cugraph/centrality/betweenness_centrality.py
+++ b/python/cugraph/cugraph/centrality/betweenness_centrality.py
@@ -81,7 +81,7 @@ def betweenness_centrality(
         If true, include the endpoints in the shortest path counts.
         (Not Supported)
 
-    seed : optional
+    seed : optional (default=None)
         if k is specified and k is an integer, use seed to initialize the
         random number generator.
         Using None as seed relies on random.seed() behavior: using current

--- a/python/cugraph/cugraph/comms/comms.py
+++ b/python/cugraph/cugraph/comms/comms.py
@@ -108,6 +108,21 @@ def initialize(comms=None,
         default) represents a partitioning resulting in prows*pcols
         partitions. A non-1 value currently results in a partitioning of
         p*pcols partitions, where p is the number of GPUs.
+
+    Examples
+    --------
+    >>> from dask.distributed import Client
+    >>> from dask_cuda import LocalCUDACluster
+    >>> import cugraph.comms as Comms
+    >>> cluster = LocalCUDACluster()
+    >>> client = Client(cluster)
+    >>> Comms.initialize(p2p=True)
+    >>> # DO WORK HERE
+    >>> # All done, clean up
+    >>> Comms.destroy()
+    >>> client.close()
+    >>> cluster.close()
+
     """
 
     global __instance
@@ -200,11 +215,17 @@ def get_default_handle():
 # Functions to be called from within workers
 
 def get_handle(sID):
+    """
+    Returns the handle from within the worker using the sessionstate.
+    """
     sessionstate = get_raft_comm_state(sID)
     return sessionstate['handle']
 
 
 def get_worker_id(sID):
+    """
+    Returns the worker's sessionId from within the worker.
+    """
     sessionstate = get_raft_comm_state(sID)
     return sessionstate['wid']
 

--- a/python/cugraph/cugraph/community/egonet.py
+++ b/python/cugraph/cugraph/community/egonet.py
@@ -163,7 +163,8 @@ def batched_ego_graphs(
     ...                   header=None)
     >>> G = cugraph.Graph()
     >>> G.from_cudf_edgelist(M, source='0', destination='1')
-    >>> b_ego_graph = cugraph.batched_ego_graphs(G, seeds=[1,5], radius=2)
+    >>> b_ego_graph, offsets = cugraph.batched_ego_graphs(G, seeds=[1,5],
+    ...                                                   radius=2)
 
     """
 

--- a/python/cugraph/cugraph/community/ktruss_subgraph.py
+++ b/python/cugraph/cugraph/community/ktruss_subgraph.py
@@ -64,6 +64,15 @@ def k_truss(G, k):
     G_truss : cuGraph.Graph or networkx.Graph
         A cugraph graph descriptor with the k-truss subgraph for the given k.
         The networkx graph will NOT have all attributes copied over
+
+    Examples
+    --------
+    >>> gdf = cudf.read_csv(datasets_path / 'karate.csv', delimiter=' ',
+    ...                     dtype=['int32', 'int32', 'float32'], header=None)
+    >>> G = cugraph.Graph()
+    >>> G.from_cudf_edgelist(gdf, source='0', destination='1')
+    >>> k_subgraph = cugraph.k_truss(G, 3)
+
     """
 
     _ensure_compatible_cuda_version()

--- a/python/cugraph/cugraph/dask/centrality/katz_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/katz_centrality.py
@@ -132,20 +132,21 @@ def katz_centrality(input_graph,
 
     Examples
     --------
-    >>> # import cugraph.dask as dcg
+    >>> import cugraph.dask as dcg
+    >>> import dask_cudf
     >>> # ... Init a DASK Cluster
     >>> #    see https://docs.rapids.ai/api/cugraph/stable/dask-cugraph.html
     >>> # Download dataset from https://github.com/rapidsai/cugraph/datasets/..
-    >>> # chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
-    >>> # ddf = dask_cudf.read_csv(input_data_path, chunksize=chunksize)
-    >>> # dg = cugraph.Graph(directed=True)
-    >>> # dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
-    >>> #                            edge_attr='value')
-    >>> # pr = dcg.katz_centrality(dg)
+    >>> chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
+    >>> ddf = dask_cudf.read_csv(datasets_path / "karate.csv",
+    ...                          chunksize=chunksize, delimiter=" ",
+    ...                          names=["src", "dst", "value"],
+    ...                          dtype=["int32", "int32", "float32"])
+    >>> dg = cugraph.Graph(directed=True)
+    >>> dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst')
+    >>> pr = dcg.katz_centrality(dg)
 
     """
-    # FIXME: Uncomment out the above (broken) example
-
     nstart = None
 
     client = default_client()

--- a/python/cugraph/cugraph/dask/common/read_utils.py
+++ b/python/cugraph/cugraph/dask/common/read_utils.py
@@ -27,10 +27,9 @@ def get_chunksize(input_path):
     Examples
     --------
     >>> import cugraph.dask as dcg
-    >>> # chunksize = dcg.get_chunksize(edge_list.csv)
+    >>> chunksize = dcg.get_chunksize(datasets_path / 'netscience.csv')
 
     """
-    # FIXME: Uncomment out the above example
 
     import os
     from glob import glob

--- a/python/cugraph/cugraph/dask/community/louvain.py
+++ b/python/cugraph/cugraph/dask/community/louvain.py
@@ -19,7 +19,6 @@ import cugraph.comms.comms as Comms
 from cugraph.dask.common.input_utils import (get_distributed_data,
                                              get_vertex_partition_offsets)
 from cugraph.dask.community import louvain_wrapper as c_mg_louvain
-from cugraph.utilities.utils import is_cuda_version_less_than
 
 import dask_cudf
 
@@ -99,26 +98,22 @@ def louvain(input_graph, max_iter=100, resolution=1.0):
 
     Examples
     --------
-    >>> # import cugraph.dask as dcg
+    >>> import cugraph.dask as dcg
+    >>> import dask_cudf
     >>> # ... Init a DASK Cluster
     >>> #    see https://docs.rapids.ai/api/cugraph/stable/dask-cugraph.html
     >>> # Download dataset from https://github.com/rapidsai/cugraph/datasets/..
-    >>> # chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
-    >>> # ddf = dask_cudf.read_csv(input_data_path, chunksize=chunksize)
-    >>> # dg = cugraph.Graph(directed=True)
-    >>> # dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
-    >>> #                            edge_attr='value')
-    >>> # parts, modularity_score = dcg.louvain(dg)
+    >>> chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
+    >>> ddf = dask_cudf.read_csv(datasets_path / "karate.csv",
+    ...                          chunksize=chunksize, delimiter=" ",
+    ...                          names=["src", "dst", "value"],
+    ...                          dtype=["int32", "int32", "float32"])
+    >>> dg = cugraph.Graph(directed=True)
+    >>> dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
+    ...                            edge_attr='value')
+    >>> parts, modularity_score = dcg.louvain(dg)
+
     """
-    # FIXME: Uncomment out the above (broken) example
-
-    # MG Louvain currently requires CUDA 10.2 or higher.
-    # FIXME: remove this check once RAPIDS drops support for CUDA < 10.2
-    if is_cuda_version_less_than((10, 2)):
-        raise NotImplementedError("Multi-GPU Louvain is not implemented for "
-                                  "this version of CUDA. Ensure CUDA version "
-                                  "10.2 or higher is installed.")
-
     # FIXME: dask methods to populate graphs from edgelists are only present on
     # DiGraph classes. Disable the Graph check for now and assume inputs are
     # symmetric DiGraphs.

--- a/python/cugraph/cugraph/dask/components/connectivity.py
+++ b/python/cugraph/cugraph/dask/components/connectivity.py
@@ -54,6 +54,24 @@ def weakly_connected_components(input_graph):
 
         Graph or matrix object, which should contain the connectivity
         information
+
+    Examples
+    --------
+    >>> import cugraph.dask as dcg
+    >>> import dask_cudf
+    >>> # ... Init a DASK Cluster
+    >>> #    see https://docs.rapids.ai/api/cugraph/stable/dask-cugraph.html
+    >>> # Download dataset from https://github.com/rapidsai/cugraph/datasets/..
+    >>> chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
+    >>> ddf = dask_cudf.read_csv(datasets_path / "karate.csv",
+    ...                          chunksize=chunksize, delimiter=" ",
+    ...                          names=["src", "dst", "value"],
+    ...                          dtype=["int32", "int32", "float32"])
+    >>> dg = cugraph.Graph(directed=True)
+    >>> dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
+    ...                            edge_attr='value')
+    >>> result = dcg.weakly_connected_components(dg)
+
     """
 
     client = default_client()

--- a/python/cugraph/cugraph/dask/link_analysis/hits.py
+++ b/python/cugraph/cugraph/dask/link_analysis/hits.py
@@ -135,16 +135,20 @@ def hits(input_graph, tol=1.0e-5, max_iter=100,  nstart=None, normalized=True):
 
     Examples
     --------
-    >>> # import cugraph.dask as dcg
+    >>> import cugraph.dask as dcg
+    >>> import dask_cudf
     >>> # ... Init a DASK Cluster
     >>> #    see https://docs.rapids.ai/api/cugraph/stable/dask-cugraph.html
     >>> # Download dataset from https://github.com/rapidsai/cugraph/datasets/..
-    >>> # chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
-    >>> # ddf = dask_cudf.read_csv(input_data_path, chunksize=chunksize)
-    >>> # dg = cugraph.Graph(directed=True)
-    >>> # dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
-    >>> #                            edge_attr='value')
-    >>> # hits = dcg.hits(dg, max_iter = 50)
+    >>> chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
+    >>> ddf = dask_cudf.read_csv(datasets_path / "karate.csv",
+    ...                          chunksize=chunksize, delimiter=" ",
+    ...                          names=["src", "dst", "value"],
+    ...                          dtype=["int32", "int32", "float32"])
+    >>> dg = cugraph.Graph(directed=True)
+    >>> dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
+    ...                            edge_attr='value')
+    >>> hits = dcg.hits(dg, max_iter = 50)
 
     """
 

--- a/python/cugraph/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/cugraph/dask/link_analysis/pagerank.py
@@ -121,16 +121,19 @@ def pagerank(input_graph,
 
     Examples
     --------
-    >>> # import cugraph.dask as dcg
+    >>> import cugraph.dask as dcg
+    >>> import dask_cudf
     >>> # ... Init a DASK Cluster
     >>> #    see https://docs.rapids.ai/api/cugraph/stable/dask-cugraph.html
     >>> # Download dataset from https://github.com/rapidsai/cugraph/datasets/..
-    >>> # chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
-    >>> # ddf = dask_cudf.read_csv(input_data_path, chunksize=chunksize)
-    >>> # dg = cugraph.Graph(directed=True)
-    >>> # dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
-    >>> #                            edge_attr='value')
-    >>> # pr = dcg.pagerank(dg)
+    >>> chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
+    >>> ddf = dask_cudf.read_csv(datasets_path / "karate.csv",
+    ...                          chunksize=chunksize, delimiter=" ",
+    ...                          names=["src", "dst", "value"],
+    ...                          dtype=["int32", "int32", "float32"])
+    >>> dg = cugraph.Graph(directed=True)
+    >>> dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst')
+    >>> pr = dcg.pagerank(dg)
 
     """
     nstart = None

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -94,19 +94,22 @@ def bfs(input_graph,
 
     Examples
     --------
-    >>> # import cugraph.dask as dcg
+    >>> import cugraph.dask as dcg
+    >>> import dask_cudf
     >>> # ... Init a DASK Cluster
     >>> #    see https://docs.rapids.ai/api/cugraph/stable/dask-cugraph.html
     >>> # Download dataset from https://github.com/rapidsai/cugraph/datasets/..
-    >>> # chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
-    >>> # ddf = dask_cudf.read_csv(input_data_path, chunksize=chunksize)
-    >>> # dg = cugraph.Graph(directed=True)
-    >>> # dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
-    >>> #                            edge_attr='value')
-    >>> # df = dcg.bfs(dg, 0)
+    >>> chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
+    >>> ddf = dask_cudf.read_csv(datasets_path / "karate.csv",
+    ...                          chunksize=chunksize, delimiter=" ",
+    ...                          names=["src", "dst", "value"],
+    ...                          dtype=["int32", "int32", "float32"])
+    >>> dg = cugraph.Graph(directed=True)
+    >>> dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
+    ...                            edge_attr='value')
+    >>> df = dcg.bfs(dg, 0)
 
     """
-    # FIXME: Uncomment out the above (broken) example
 
     client = default_client()
 

--- a/python/cugraph/cugraph/dask/traversal/sssp.py
+++ b/python/cugraph/cugraph/dask/traversal/sssp.py
@@ -84,16 +84,22 @@ def sssp(input_graph, source):
 
     Examples
     --------
-    >>> # import cugraph.dask as dcg
-    >>> #... Init a DASK Cluster
-    >>> #   see https://docs.rapids.ai/api/cugraph/stable/dask-cugraph.html
-    >>> # chunksize = dcg.get_chunksize(input_data_path)
-    >>> # ddf = dask_cudf.read_csv(input_data_path, chunksize=chunksize...)
-    >>> # dg = cugraph.Graph(directed=True)
-    >>> # dg.from_dask_cudf_edgelist(ddf, 'src', 'dst')
-    >>> # df = dcg.sssp(dg, 0)
+    >>> import cugraph.dask as dcg
+    >>> import dask_cudf
+    >>> # ... Init a DASK Cluster
+    >>> #    see https://docs.rapids.ai/api/cugraph/stable/dask-cugraph.html
+    >>> # Download dataset from https://github.com/rapidsai/cugraph/datasets/..
+    >>> chunksize = dcg.get_chunksize(datasets_path / "karate.csv")
+    >>> ddf = dask_cudf.read_csv(datasets_path / "karate.csv",
+    ...                          chunksize=chunksize, delimiter=" ",
+    ...                          names=["src", "dst", "value"],
+    ...                          dtype=["int32", "int32", "float32"])
+    >>> dg = cugraph.Graph(directed=True)
+    >>> dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
+    ...                            edge_attr='value')
+    >>> df = dcg.sssp(dg, 0)
+
     """
-    # FIXME: Uncomment out the above (broken) example
 
     client = default_client()
 

--- a/python/cugraph/cugraph/linear_assignment/lap.py
+++ b/python/cugraph/cugraph/linear_assignment/lap.py
@@ -69,7 +69,6 @@ def hungarian(G, workers, epsilon=None):
     >>> cost, df = cugraph.hungarian(G, workers)
 
     """
-    # FIXME: Create bipartite.csv and uncomment out the above example
 
     if G.renumbered:
         if isinstance(workers, cudf.DataFrame):

--- a/python/cugraph/cugraph/sampling/node2vec.py
+++ b/python/cugraph/cugraph/sampling/node2vec.py
@@ -81,8 +81,8 @@ def node2vec(G,
     sizes: int or cudf.Series
         The path size or sizes in case of coalesced paths.
 
-    Example
-    -------
+    Examples
+    --------
     >>> M = cudf.read_csv(datasets_path / 'karate.csv', delimiter=' ',
     ...                   dtype=['int32', 'int32', 'float32'], header=None)
     >>> G = cugraph.Graph()

--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -167,6 +167,13 @@ def hypergraph(
         entities : cudf.DataFrame
             A DataFrame of the found entity node attributes.
 
+    Examples
+    --------
+    >>> M = cudf.read_csv(datasets_path / 'karate.csv', delimiter=' ',
+    ...                   names=['src', 'dst', 'weights'],
+    ...                   dtype=['int32', 'int32', 'float32'], header=None)
+    >>> nodes, edges, G, events, entities = cugraph.hypergraph(M)
+
     """
 
     columns = values.columns if columns is None else columns

--- a/python/cugraph/cugraph/tests/dask/test_mg_doctests.py
+++ b/python/cugraph/cugraph/tests/dask/test_mg_doctests.py
@@ -23,14 +23,18 @@ import scipy
 import pytest
 
 import cugraph
-import pylibcugraph
 import cudf
-from numba import cuda
 from cugraph.tests import utils
 
+from dask.distributed import Client
+from dask_cuda import LocalCUDACluster
+import cugraph.comms as Comms
 
-modules_to_skip = ["dask", "proto", "raft"]
 datasets = utils.RAPIDS_DATASET_ROOT_DIR_PATH
+
+cluster = LocalCUDACluster()
+client = Client(cluster)
+Comms.initialize(p2p=True)
 
 
 def _is_public_name(name):
@@ -45,17 +49,10 @@ def _module_from_library(member, libname):
     return libname in member.__module__
 
 
-def _file_from_library(member, libname):
-    return libname in member.__file__
-
-
-def _find_modules_in_obj(finder, obj, obj_name, criteria=None):
-    for name, member in inspect.getmembers(obj):
-        if criteria is not None and not criteria(name):
-            continue
-        if inspect.ismodule(member) and (member not in modules_to_skip):
-            yield from _find_doctests_in_obj(finder, member, obj_name,
-                                             _is_public_name)
+def _find_doctests_in_docstring(finder, member):
+    for docstring in finder.find(member):
+        if docstring.examples:
+            yield docstring
 
 
 def _find_doctests_in_obj(finder, obj, obj_name, criteria=None):
@@ -68,6 +65,10 @@ def _find_doctests_in_obj(finder, obj, obj_name, criteria=None):
     obj : module or class
         The object to search for docstring examples.
 
+    obj_name : string
+        Used for ensuring a module is part of the object.
+        To be passed into _module_from_library.
+
     criteria : callable, optional
 
     Yields
@@ -75,14 +76,12 @@ def _find_doctests_in_obj(finder, obj, obj_name, criteria=None):
     doctest.DocTest
         The next doctest found in the object.
     """
-    for name, member in inspect.getmembers(obj):
+    for name, member in inspect.getmembers(obj, inspect.isfunction):
         if criteria is not None and not criteria(name):
             continue
-
         if inspect.ismodule(member):
-            if _file_from_library(member, obj_name) and \
-               _is_python_module(member):
-                _find_doctests_in_obj(finder, member, obj_name, criteria)
+            yield from _find_doctests_in_obj(finder, member, obj_name,
+                                             criteria)
         if inspect.isfunction(member):
             yield from _find_doctests_in_docstring(finder, member)
         if inspect.isclass(member):
@@ -90,19 +89,10 @@ def _find_doctests_in_obj(finder, obj, obj_name, criteria=None):
                 yield from _find_doctests_in_docstring(finder, member)
 
 
-def _find_doctests_in_docstring(finder, member):
-    for docstring in finder.find(member):
-        if docstring.examples:
-            if 'dask' not in str(docstring):
-                yield docstring
-
-
 def _fetch_doctests():
     finder = doctest.DocTestFinder()
-    yield from _find_modules_in_obj(finder, cugraph, 'cugraph',
-                                    _is_public_name)
-    yield from _find_modules_in_obj(finder, pylibcugraph, 'pylibcugraph',
-                                    _is_public_name)
+    yield from _find_doctests_in_obj(finder, cugraph.dask, 'dask',
+                                     _is_public_name)
 
 
 class TestDoctests:
@@ -118,7 +108,7 @@ class TestDoctests:
             os.chdir(original_directory)
 
     @pytest.mark.parametrize(
-        "docstring", _fetch_doctests(), ids=lambda docstring: docstring.name
+        "docstring", _fetch_doctests(), ids=lambda docstring: docstring.name,
     )
     def test_docstring(self, docstring):
         # We ignore differences in whitespace in the doctest output, and enable
@@ -133,13 +123,6 @@ class TestDoctests:
                      scipy=scipy, pd=pd)
         docstring.globs = globs
 
-        # FIXME: A 11.4 bug causes ktruss to crash in that
-        # environment. Skip docstring test if the cuda version is either
-        # 11.2 or 11.4. See ktruss_subgraph.py
-        if docstring.name == 'ktruss_subgraph':
-            if cuda.runtime.get_version() == (11, 4):
-                return
-
         # Capture stdout and include failing outputs in the traceback.
         doctest_stdout = io.StringIO()
         with contextlib.redirect_stdout(doctest_stdout):
@@ -149,3 +132,9 @@ class TestDoctests:
             f"{results.failed} of {results.attempted} doctests failed for "
             f"{docstring.name}:\n{doctest_stdout.getvalue()}"
         )
+
+    def close_comms():
+        Comms.destroy()
+        client.close()
+        if cluster:
+            cluster.close()

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -101,6 +101,21 @@ cdef class SGGraph(_GPUGraph):
     do_expensive_check : bool
         If True, performs more extensive tests on the inputs to ensure
         validitity, at the expense of increased run time.
+    
+    Examples
+    ---------
+    >>> import pylibcugraph, cupy, numpy
+    >>> srcs = cupy.asarray([0, 1, 2], dtype=numpy.int32)
+    >>> dsts = cupy.asarray([1, 2, 3], dtype=numpy.int32)
+    >>> seeds = cupy.asarray([0, 0, 1], dtype=numpy.int32)
+    >>> weights = cupy.asarray([1.0, 1.0, 1.0], dtype=numpy.float32)
+    >>> resource_handle = pylibcugraph.experimental.ResourceHandle()
+    >>> graph_props = pylibcugraph.experimental.GraphProperties(
+    ...     is_symmetric=False, is_multigraph=False)
+    >>> G = pylibcugraph.experimental.SGGraph(
+    ...     resource_handle, graph_props, srcs, dsts, weights,
+    ...     store_transposed=False, renumber=False, do_expensive_check=False)
+
     """
     def __cinit__(self,
                   ResourceHandle resource_handle,


### PR DESCRIPTION
This PR incorporates suggested changes from issue #2037, opened back in 22.02, as well as cleaning up documentation and testing code from 22.04 work.

Specifically, this PR does the following:
- Removes worker helpers from MNMG algos in the online documentation (e.g. `call_katz_centrality`, `call_louvain`, `call_wcc`)
- Adds helpers from comms such as `get_comms`, `get_session_id`, `get_2D_partition`, is_initialized that were previously missing
- Adds helpers from NumberMap such as `from_internal_vertex_id`, `to_internal_vertex_id`, `renumber`, `set_renumbered_col_names`
- Add MNMG Hits and Node2vec to docs
- Added docstring descriptions and examples to methods that were missing them
- Fixed docstring examples in `egonet.py`, `node2vec.py`
- Adds `pylibcugraph` docstring examples to the list of examples tested in `cugraph/tests/test_doctests.py`
- Adds support for MG Dask docstring example testing, tested in newly created `cugraph/tests/dask/test_mg_doctests.py` 

This PR addresses the items from and closes https://github.com/rapidsai/cugraph/issues/2227.
This PR also closes #2193.

Authors:
  - https://github.com/betochimas

Approvers:
  - Rick Ratzel (https://github.com/rlratzel)

URL: https://github.com/rapidsai/cugraph/pull/2194